### PR TITLE
fix: set archivePath to dsinput

### DIFF
--- a/data/packages_list.xml
+++ b/data/packages_list.xml
@@ -561,7 +561,7 @@
 		<latestVersion>ver0.26a</latestVersion>
 		<detailURL />
 		<files>
-			<file>plugins/ds_input.aui</file>
+			<file archivePath="ds_input/">plugins/ds_input.aui</file>
 		</files>
 	</package>
 


### PR DESCRIPTION
This commit fixes the problem that "apm" cannot install "DirectShow File Reader プラグイン for AviUtl"
Related to hal-shu-sato/apm#99