### PR TITLE
fix: fix the problem that all scripts are uninstalled on uninstalling "拡張編集RAMプレビュー"

### DIFF
--- a/data/packages_list.xml
+++ b/data/packages_list.xml
@@ -488,7 +488,7 @@
 			<file>ZRamPreview.auf</file>
 			<file>ZRamPreview.auo</file>
 			<file>ZRamPreview.exe</file>
-			<file directory="true">script</file>
+			<file archivePath="script/">script/Extram.dll</file>
 		</files>
 	</package>
 


### PR DESCRIPTION
This commit fixes the problem that all scripts are uninstalled on uninstalling "拡張編集RAMプレビュー".