### PR TITLE
fix: fix a problem that uninstalling x264guiEx/x265guiEx affects other packages

### DIFF
--- a/data/mod.xml
+++ b/data/mod.xml
@@ -2,5 +2,5 @@
 <?xml-model href="../schema/mod.xsd" type="application/xml" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <mod>
 	<core>2021-06-20T12:05:00+09:00</core>
-	<packages_list>2021-09-12T17:30:00+09:00</packages_list>
+	<packages_list>2021-09-12T17:45:00+09:00</packages_list>
 </mod>

--- a/data/mod.xml
+++ b/data/mod.xml
@@ -2,5 +2,5 @@
 <?xml-model href="../schema/mod.xsd" type="application/xml" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <mod>
 	<core>2021-06-20T12:05:00+09:00</core>
-	<packages_list>2021-09-11T18:40:00+09:00</packages_list>
+	<packages_list>2021-09-12T17:30:00+09:00</packages_list>
 </mod>

--- a/data/packages_list.xml
+++ b/data/packages_list.xml
@@ -1073,7 +1073,12 @@
 		    <file>plugins/x265guiEx.auo</file>
 			<file>plugins/x265guiEx.conf</file>
 			<file>plugins/x265guiEx.ini</file>
-			<file directory="true">exe_files</file>
+			<file>exe_files/boxdumper.exe</file>
+			<file>exe_files/ffmpeg_audenc.exe</file>
+			<file>exe_files/muxer.exe</file>
+			<file>exe_files/remuxer.exe</file>
+			<file>exe_files/timelineeditor.exe</file>
+			<file>exe_files/x265_3.4+19_x64.exe</file>
 			<file directory="true">plugins/x265guiEx_stg</file>
 		</files>
 	</package>

--- a/data/packages_list.xml
+++ b/data/packages_list.xml
@@ -880,7 +880,7 @@
 				directory="true"
 			>plugins/ffmpegOut_stg</file>
 		</files>
-	</package>	
+	</package>
 
 	<package>
 		<id>NVEnc</id>
@@ -978,7 +978,7 @@
 		<files>
 			<file archivePath="pmd_mt+6">plugins/pmd_mt.auf</file>
 		</files>
-	</package>	
+	</package>
 
 	<package>
 		<id>svtAV1guiEx</id>
@@ -1000,7 +1000,7 @@
 			<file archivePath="svtAV1guiEx_0.05/auo">plugins/svtAV1guiEx.auo</file>
 			<file archivePath="svtAV1guiEx_0.05/auo">plugins/svtAV1guiEx.ini</file>
 		</files>
-	</package>	
+	</package>
 
 	<package>
 		<id>VCEEnc</id>
@@ -1044,7 +1044,12 @@
 			<file>plugins/x264guiEx.auo</file>
 			<file>plugins/x264guiEx.conf</file>
 			<file>plugins/x264guiEx.ini</file>
-			<file directory="true">exe_files</file>
+			<file>exe_files/boxdumper.exe</file>
+			<file>exe_files/ffmpeg_audenc.exe</file>
+			<file>exe_files/muxer.exe</file>
+			<file>exe_files/remuxer.exe</file>
+			<file>exe_files/timelineeditor.exe</file>
+			<file>exe_files/x264_3065_x64.exe</file>
 			<file directory="true">plugins/x264guiEx_stg</file>
 		</files>
 	</package>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix a problem that uninstalling x264guiEx/x265guiEx affects other packages.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by uninstalling x264guiEx/x265guiEx after installing QSVEnc.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The XML file has been formatted by prettier
- [x] Updated the modification date in `mod.xml`.
