### PR TITLE
feat: add hash to the versions

### DIFF
--- a/data/core.xml
+++ b/data/core.xml
@@ -12,8 +12,16 @@
 		</files>
 		<latestVersion>1.10</latestVersion>
 		<releases prefix="http://spring-fragrance.mints.ne.jp/aviutl/">
-			<fileURL version="1.10">aviutl110.zip</fileURL>
-			<fileURL version="1.00">aviutl100.zip</fileURL>
+			<fileURL
+				version="1.10"
+				hashTarget="aviutl.exe"
+				hashTargetSHA256="3737D8B0BC1336624BFB7F7C54425C819A208B5FEEE552F5CE9443DD4C6A1A04"
+			>aviutl110.zip</fileURL>
+			<fileURL
+				version="1.00"
+				hashTarget="aviutl.exe"
+				hashTargetSHA256="B8FFAF79853686C41A8033AF04607325FF9454BE9D3C2365D81D6924FFC34A40"
+			>aviutl100.zip</fileURL>
 		</releases>
 	</aviutl>
 	<exedit>
@@ -34,8 +42,16 @@
 		</files>
 		<latestVersion>0.92</latestVersion>
 		<releases prefix="http://spring-fragrance.mints.ne.jp/aviutl/">
-			<fileURL version="0.93rc1">exedit93rc1.zip</fileURL>
-			<fileURL version="0.92">exedit92.zip</fileURL>
+			<fileURL
+				version="0.93rc1"
+				hashTarget="exedit.auf"
+				hashTargetSHA256="319BA428C4528A528171A8F898DA7AD2D246E4A6A7FDF9136C3296986C015E05"
+			>exedit93rc1.zip</fileURL>
+			<fileURL
+				version="0.92"
+				hashTarget="exedit.auf"
+				hashTargetSHA256="06F2D89D31D6B8F5D1D8B079A2872A467F3C704ED38355E1F19F1FBD9529EE3A"
+			>exedit92.zip</fileURL>
 		</releases>
 	</exedit>
 </core>

--- a/data/core.xml
+++ b/data/core.xml
@@ -14,13 +14,13 @@
 		<releases prefix="http://spring-fragrance.mints.ne.jp/aviutl/">
 			<fileURL
 				version="1.10"
-				hashTarget="aviutl.exe"
-				hashTargetSHA256="3737D8B0BC1336624BFB7F7C54425C819A208B5FEEE552F5CE9443DD4C6A1A04"
+				target="aviutl.exe"
+				targetIntegrity="sha384-BsJg59A0t7oHOZp54iljF4nB2V6tYzHiPhYW/h16Oz3qE7qhFFXx6AvhdajnwKfD"
 			>aviutl110.zip</fileURL>
 			<fileURL
 				version="1.00"
-				hashTarget="aviutl.exe"
-				hashTargetSHA256="B8FFAF79853686C41A8033AF04607325FF9454BE9D3C2365D81D6924FFC34A40"
+				target="aviutl.exe"
+				targetIntegrity="sha384-TrRFAxOVGtJIhyWV20dXHEOmss96xEHYHaNE4/+t3kvxUGF3IjOP55AnznoNzMom"
 			>aviutl100.zip</fileURL>
 		</releases>
 	</aviutl>
@@ -44,13 +44,13 @@
 		<releases prefix="http://spring-fragrance.mints.ne.jp/aviutl/">
 			<fileURL
 				version="0.93rc1"
-				hashTarget="exedit.auf"
-				hashTargetSHA256="319BA428C4528A528171A8F898DA7AD2D246E4A6A7FDF9136C3296986C015E05"
+				target="exedit.auf"
+				targetIntegrity="sha384-Zbt+Oc8pG3dGXmPqr3c767Y5/3/FaSVngmipn0v1KyXRW8dWVZuOZ2WTrP09YRDZ"
 			>exedit93rc1.zip</fileURL>
 			<fileURL
 				version="0.92"
-				hashTarget="exedit.auf"
-				hashTargetSHA256="06F2D89D31D6B8F5D1D8B079A2872A467F3C704ED38355E1F19F1FBD9529EE3A"
+				target="exedit.auf"
+				targetIntegrity="sha384-aW5769CsMnmDGnZzNzqP4KFvM2npA8gfopzwB//TBbwYfoLZtGvoP/oXZctVEZxp"
 			>exedit92.zip</fileURL>
 		</releases>
 	</exedit>

--- a/data/mod.xml
+++ b/data/mod.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <?xml-model href="../schema/mod.xsd" type="application/xml" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <mod>
-	<core>2021-06-20T12:05:00+09:00</core>
+	<core>2021-11-20T11:30:00+09:00</core>
 	<packages_list>2021-11-14T13:00:00+09:00</packages_list>
 </mod>

--- a/schema/au.xsd
+++ b/schema/au.xsd
@@ -11,8 +11,8 @@
 					<xsd:simpleContent>
 						<xsd:extension base="xsd:anyURI">
 							<xsd:attribute name="version" type="xsd:string" use="required" />
-							<xsd:attribute name="hashTarget" type="xsd:string" use="optional" />
-							<xsd:attribute name="hashTargetSHA256" type="xsd:string" use="optional" />
+							<xsd:attribute name="target" type="xsd:string" use="optional" />
+							<xsd:attribute name="targetIntegrity" type="xsd:string" use="optional" />
 						</xsd:extension>
 					</xsd:simpleContent>
 				</xsd:complexType>

--- a/schema/au.xsd
+++ b/schema/au.xsd
@@ -11,6 +11,8 @@
 					<xsd:simpleContent>
 						<xsd:extension base="xsd:anyURI">
 							<xsd:attribute name="version" type="xsd:string" use="required" />
+							<xsd:attribute name="hashTarget" type="xsd:string" use="optional" />
+							<xsd:attribute name="hashTargetSHA256" type="xsd:string" use="optional" />
 						</xsd:extension>
 					</xsd:simpleContent>
 				</xsd:complexType>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use hashes to estimate the version of a manually installed program. This should not be a breaking change and needs to be tested with the current version of apm.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
You can install aviutl and exedit with this xml loaded in the current version of apm.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Updated the modification date in `mod.xml`.
