### PR TITLE
fix: remove a batch installation package

### DIFF
--- a/v2/data/mod.xml
+++ b/v2/data/mod.xml
@@ -2,6 +2,6 @@
 <?xml-model href="../schema/mod.xsd" type="application/xml" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <mod version="2">
 	<core>2021-12-27T22:23:00+09:00</core>
-	<packages>2022-01-05T05:48:00+09:00</packages>
+	<packages>2022-01-29T15:22:00+09:00</packages>
 	<convert>2021-12-11T16:03:00+09:00</convert>
 </mod>

--- a/v2/data/packages.xml
+++ b/v2/data/packages.xml
@@ -2300,8 +2300,6 @@
 		<originalDeveloper>VFR-maniac</originalDeveloper>
 		<pageURL>https://pop.4-bit.jp/?page_id=7929</pageURL>
 		<downloadURL>https://pop.4-bit.jp/?page_id=7929</downloadURL>
-		<directURL
-		>https://pop.4-bit.jp/bin/l-smash/L-SMASH_Works_r940_plugins.zip</directURL>
 		<latestVersion>r940 release1</latestVersion>
 		<files>
 			<file>plugins/lwcolor.auc</file>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Prevent the bulk install function from freezing by removing packages whose certificates have been revoked.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- closes https://github.com/hal-shu-sato/apm/issues/343

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Batch installation was performed with apm v2.0.0.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Updated the modification date in `mod.xml`.
