### PR TITLE
fix: fix to patch.aul installation path

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -53,6 +53,7 @@ This file contains data of plugins and scripts.
   - _/packages/package/files/file/@optional_: Whether it is optional during installation (Default: false)
   - _/packages/package/files/file/@directory_: Whether it is a directory (Default: false)
   - _/packages/package/files/file/@archivePath_: The relative path of the file in the archive (Default: null)
+  - _/packages/package/files/file/@obsolete_: Whether it is not included in the latest version (Default: false)
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ AviUtlと拡張編集Pluginのデータファイル
   - _/packages/package/files/file/@optional_: インストール時に必要ないかどうか (デフォルト: false)
   - _/packages/package/files/file/@directory_: ディレクトリかどうか (デフォルト: false)
   - _/packages/package/files/file/@archivePath_: ファイルのアーカイブ内相対パス (デフォルト: null)
+  - _/packages/package/files/file/@obsolete_: 最新バージョンに存在しないかどうか (デフォルト: false)
 
 ## コントリビューション
 

--- a/v2/data/mod.xml
+++ b/v2/data/mod.xml
@@ -2,6 +2,6 @@
 <?xml-model href="../schema/mod.xsd" type="application/xml" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <mod version="2">
 	<core>2021-12-27T22:23:00+09:00</core>
-	<packages>2022-03-06T17:44:00+09:00</packages>
+	<packages>2022-03-14T21:59:00+09:00</packages>
 	<convert>2021-12-11T16:03:00+09:00</convert>
 </mod>

--- a/v2/data/packages.xml
+++ b/v2/data/packages.xml
@@ -785,7 +785,8 @@
 		<downloadURL>https://scrapbox.io/ePi5131/patch.aul</downloadURL>
 		<latestVersion>r14</latestVersion>
 		<files>
-			<file>plugins/patch.aul</file>
+			<file>patch.aul</file>
+			<file obsolete="true">plugins/patch.aul</file>
 			<file optional="true">plugins/patch.aul.json</file>
 		</files>
 		<releases>

--- a/v2/schema/au.xsd
+++ b/v2/schema/au.xsd
@@ -27,6 +27,12 @@
 								type="xsd:string"
 								use="optional"
 							/>
+							<xsd:attribute
+								name="obsolete"
+								type="xsd:boolean"
+								default="false"
+								use="optional"
+							/>
 						</xsd:extension>
 					</xsd:simpleContent>
 				</xsd:complexType>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A fix to the patch.aul installation path, with the addition of an obsolete flag.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/hal-shu-sato/apm/pull/399
  - Do not merge this PR until [#399](https://github.com/hal-shu-sato/apm/pull/399) is released.
- closes https://github.com/hal-shu-sato/apm-data/issues/123

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Updated the modification date in `mod.xml`.
