### PR TITLE
refactor: make some XML files strict

### DIFF
--- a/v2/data/core.xml
+++ b/v2/data/core.xml
@@ -54,14 +54,12 @@
 			<file>exedit.txt</file>
 			<file>lua.txt</file>
 			<file>lua51.dll</file>
+			<file optional="true">lua51jit.dll</file>
 		</files>
 
 		<releases>
 			<release version="0.93rc1">
 				<url>http://spring-fragrance.mints.ne.jp/aviutl/exedit93rc1.zip</url>
-				<files>
-					<file>lua51jit.dll</file>
-				</files>
 				<archiveIntegrity
 				>sha384-tTGQHYA16JBSXELzf7w0PAavkkoOjZFC6cWJzG3l2EssP5jeZO+Ou0xndh/vOolW</archiveIntegrity>
 				<integrities>

--- a/v2/data/mod.xml
+++ b/v2/data/mod.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <?xml-model href="../schema/mod.xsd" type="application/xml" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <mod version="2">
-	<core>2021-12-27T22:23:00+09:00</core>
-	<packages>2022-04-02T05:48:00+09:00</packages>
+	<core>2022-04-04T18:12:00+09:00</core>
+	<packages>2022-04-04T18:12:00+09:00</packages>
 	<convert>2021-12-11T16:03:00+09:00</convert>
 	<scripts>2022-02-19T14:28:00+09:00</scripts>
 </mod>

--- a/v2/data/packages.xml
+++ b/v2/data/packages.xml
@@ -41,7 +41,7 @@
 		<description
 		>ファイルの入力、分離、デコードに、Media Foundation を使っており、DXVA2(GPU)を利用した高速なデコードが可能です</description>
 		<developer>amate</developer>
-		<pageURL />
+		<pageURL>https://github.com/amate/MFVideoReader</pageURL>
 		<downloadURL
 		>https://github.com/amate/MFVideoReader/releases/latest</downloadURL>
 		<latestVersion>v1.0</latestVersion>
@@ -1220,7 +1220,7 @@
 	<package>
 		<id>karoterra/MarkdownEX</id>
 		<name>AviUtl MarkdownEX</name>
-		<overview>aviutl_browserを使ってAviUtlでMarkdownを表示するスクリプト</overview>
+		<overview>aviutl_browserを利用してMarkdownを表示する</overview>
 		<description
 		>aviutl_browserを使ってAviUtlでMarkdownを表示するスクリプト。aviutl_browser同梱のMarkdown.anmを元に機能拡張を行ったものです。</description>
 		<developer>karoterra</developer>
@@ -1742,7 +1742,7 @@
 		<description
 		>これは PSDTool(https://oov.github.com/psdtool/) でシンプルビューを元にして出力できる PRIMA (Pre-Rendered IMage Archive) ファイルを AviUtl で読み込めるようにする AviUtl 用入力プラグインです。</description>
 		<developer>oov</developer>
-		<pageURL />
+		<pageURL>https://github.com/oov/aviutl_prima</pageURL>
 		<downloadURL>https://github.com/oov/aviutl_prima/releases/latest</downloadURL>
 		<latestVersion>v0.1</latestVersion>
 		<files>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Strict v2 data for automatic generation of v3 data. Currently `files` in the `release` tag are not read by apm and are safe to delete.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Updated the modification date in `mod.xml`.
