### PR TITLE
fix: change the download URL of patch.aul

### DIFF
--- a/v2/data/mod.xml
+++ b/v2/data/mod.xml
@@ -2,7 +2,7 @@
 <?xml-model href="../schema/mod.xsd" type="application/xml" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <mod version="2">
 	<core>2022-04-04T18:12:00+09:00</core>
-	<packages>2022-04-15T05:48:00+09:00</packages>
+	<packages>2022-04-15T12:40:00+09:00</packages>
 	<convert>2021-12-11T16:03:00+09:00</convert>
 	<scripts>2022-02-19T14:28:00+09:00</scripts>
 </mod>

--- a/v2/data/packages.xml
+++ b/v2/data/packages.xml
@@ -808,10 +808,11 @@
 			<dependency>exedit0.92</dependency>
 		</dependencies>
 		<pageURL>https://scrapbox.io/ePi5131/patch.aul</pageURL>
-		<downloadURL>https://scrapbox.io/ePi5131/patch.aul</downloadURL>
-		<latestVersion>r14</latestVersion>
+		<downloadURL>https://github.com/ePi5131/patch.aul/releases/latest</downloadURL>
+		<latestVersion>r19</latestVersion>
 		<files>
 			<file>patch.aul</file>
+			<file optional="true">patch.aul.json</file>
 			<file obsolete="true">plugins/patch.aul</file>
 			<file optional="true">plugins/patch.aul.json</file>
 		</files>
@@ -819,7 +820,7 @@
 			<release version="r8">
 				<integrities>
 					<integrity
-						target="plugins/patch.aul"
+						target="patch.aul"
 					>sha384-Y5+kwXflyU0gp355bol79vADMCZVIZz0yV8mcPXB0lLxNRLxEzqfOJM8BpU1Td9Y</integrity>
 				</integrities>
 			</release>
@@ -828,7 +829,7 @@
 				>sha384-7cWPCn0miWYLWiAcIEVyDkZFidAPTZQQzMPRHsgaoUWIL7v2x3N+L96L+tjm4BAO</archiveIntegrity>
 				<integrities>
 					<integrity
-						target="plugins/patch.aul"
+						target="patch.aul"
 					>sha384-6W9VOV37w21UVMqBX2ItjSbTWarxkXg/DoQUjJpQaLpJRtIt8+itur5Vm3Q6wwOu</integrity>
 				</integrities>
 			</release>
@@ -837,8 +838,17 @@
 				>sha384-F12wUu5o4f0Q4x7j86plKB7v1xNxB8EOKPXdJnHLnr+liunQN2CN8ViLvSUR6ohZ</archiveIntegrity>
 				<integrities>
 					<integrity
-						target="plugins/patch.aul"
+						target="patch.aul"
 					>sha384-tPCOyr4p2z/P+/eiuCz2ItcGoMGhBQRM43+jCheRLNzse9P4VCYz7TJiCGl1IaZX</integrity>
+				</integrities>
+			</release>
+			<release version="r19">
+				<archiveIntegrity
+				>sha384-5+jMRlIpcax35H+fO4LOiCGT9Aul9ojWmAwe/Dlx/1rCNxRHD+/EQl+2Va4MmG6/</archiveIntegrity>
+				<integrities>
+					<integrity
+						target="patch.aul"
+					>sha384-CbHLDY6VKlgWNQPE04LkX0DeyMJBiD/Q+Ma744JSanagv8439iURG/Ldvu050ul5</integrity>
 				</integrities>
 			</release>
 		</releases>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Change the download URL of the patch.aul.
- Update version to the latest version.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

apm v2.1.1 could install it correctly.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Updated the modification date in `mod.xml`.
